### PR TITLE
patch: Introducing a second variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
 # pandoc-vex
 
->**Note** This pandoc filter is aimed at solving a specific problem related to the drafting of agreements subject to the Italian Law, so the remainder of this README will be in Italian language only.
+>**Note** This pandoc filter is aimed at solving a specific problem related to the drafting of agreements subject to the Italian Law, so the remainder of this README will be mainly in Italian language.
+
+# English
+
+This is a filter to create one or more lists of clauses in an agreement. Under Italian Law you are required to approve certain clauses in writing, but this could be used to create an arbitrary list of clauses, for instance, sections whose breach would cause immediata termination. It is used in a markdown agreement compiled with  pandoc and pandoc-crossref.
+
+## Install
+
+1. Install panflute: `sudo pip3 install panflute`
+2. Copy pandox-vex to a PATH directory and make it executable: `sudo cp pandoc-vex /usr/local/bin/ && sudo chmod +x /usr/local/bin/pandoc-vex`
+
+Syntax: Unique prefix  `sec:` e attribute `vex` *or* `ris` *or both*
+
+Any reference within the text of literal `@vex` and/or `@ris` will be replaced by a list of clauses (number + headings) which are marked with those attributes mentioned above.
+
+**Note**: all relevant headings must be *above* the reference, or they will be missed. So ideally those list must be at the end of the contract.
+
+## Use
+
+Must be in a cascade just before pandoc-crossref, such as in:
+
+```
+pandoc \
+  --filter=pandoc-vex \
+  --filter=pandoc-crossref \
+  contratto.md -o contratto.docx
+```
+
+# Italiano
 
 Filtro per pandoc per creare automaticamente una lista delle clausole vessatorie (da approvare specificamente per iscritto ex artt.1341-2 c.c.) alla fine di un contratto redatto in linguaggio markdown e compilato con pandoc e pandoc-crossref.
 

--- a/pandoc-vex
+++ b/pandoc-vex
@@ -17,14 +17,35 @@
 import panflute as pf
 
 vex = []
+ris = []
 
 def action(elem, doc):
     global vex
+    global ris
     if isinstance(elem, pf.Header) and elem.attributes.get('vex'):
         vex.append({
             'id': elem.identifier,
             'title': pf.stringify(elem)
         })
+
+        if isinstance(elem, pf.Header) and elem.attributes.get('ris'):
+            ris.append({
+                'id': elem.identifier,
+                'title': pf.stringify(elem)
+            })
+
+    elif isinstance(elem, pf.Header) and elem.attributes.get('ris'):
+        ris.append({
+            'id': elem.identifier,
+            'title': pf.stringify(elem)
+        })
+
+        if isinstance(elem, pf.Header) and elem.attributes.get('vex'):
+            vex.append({
+            'id': elem.identifier,
+            'title': pf.stringify(elem)
+            })
+
     elif isinstance(elem, pf.Cite) and pf.stringify(elem) == "@vex":
         vex_list = [
             "@{} ({})".format(v['id'], v['title'])
@@ -37,5 +58,18 @@ def action(elem, doc):
         new_elem.content = vex_list_pandoc[0].content
         return new_elem
 
+    elif isinstance(elem, pf.Cite) and pf.stringify(elem) == "@ris":
+        ris_list = [
+            "@{} ({})".format(v['id'], v['title'])
+            for v in ris
+        ]
+        ris_list_str = ", ".join(ris_list)
+        ris_list_pandoc = pf.convert_text(ris_list_str)
+        # convert_text returns a Para obj, copying its content in a Span obj
+        new_elem = pf.Span()
+        new_elem.content = ris_list_pandoc[0].content
+        return new_elem
+
 if __name__ == '__main__':
     pf.toJSONFilter(action)
+    # pf.toJSONFilter(insert_clauses)

--- a/pandoc-vex
+++ b/pandoc-vex
@@ -22,53 +22,48 @@ ris = []
 def action(elem, doc):
     global vex
     global ris
-    if isinstance(elem, pf.Header) and elem.attributes.get('vex'):
-        vex.append({
-            'id': elem.identifier,
-            'title': pf.stringify(elem)
-        })
+    if isinstance(elem, pf.Header):
 
-        if isinstance(elem, pf.Header) and elem.attributes.get('ris'):
+        if elem.attributes.get('vex'):
+            vex.append({
+                'id': elem.identifier,
+                'title': pf.stringify(elem)
+            })
+
+
+        if elem.attributes.get('ris'):
             ris.append({
                 'id': elem.identifier,
                 'title': pf.stringify(elem)
             })
 
-    elif isinstance(elem, pf.Header) and elem.attributes.get('ris'):
-        ris.append({
-            'id': elem.identifier,
-            'title': pf.stringify(elem)
-        })
+        
 
-        if isinstance(elem, pf.Header) and elem.attributes.get('vex'):
-            vex.append({
-            'id': elem.identifier,
-            'title': pf.stringify(elem)
-            })
+    elif isinstance(elem, pf.Cite):
 
-    elif isinstance(elem, pf.Cite) and pf.stringify(elem) == "@vex":
-        vex_list = [
-            "@{} ({})".format(v['id'], v['title'])
-            for v in vex
-        ]
-        vex_list_str = ", ".join(vex_list)
-        vex_list_pandoc = pf.convert_text(vex_list_str)
-        # convert_text returns a Para obj, copying its content in a Span obj
-        new_elem = pf.Span()
-        new_elem.content = vex_list_pandoc[0].content
-        return new_elem
+        if pf.stringify(elem) == "@vex":
+            vex_list = [
+                "@{} ({})".format(v['id'], v['title'])
+                for v in vex
+            ]
+            vex_list_str = ", ".join(vex_list)
+            vex_list_pandoc = pf.convert_text(vex_list_str)
+            # convert_text returns a Para obj, copying its content in a Span obj
+            new_elem = pf.Span()
+            new_elem.content = vex_list_pandoc[0].content
+            return new_elem
 
-    elif isinstance(elem, pf.Cite) and pf.stringify(elem) == "@ris":
-        ris_list = [
-            "@{} ({})".format(v['id'], v['title'])
-            for v in ris
-        ]
-        ris_list_str = ", ".join(ris_list)
-        ris_list_pandoc = pf.convert_text(ris_list_str)
-        # convert_text returns a Para obj, copying its content in a Span obj
-        new_elem = pf.Span()
-        new_elem.content = ris_list_pandoc[0].content
-        return new_elem
+        elif pf.stringify(elem) == "@ris":
+            ris_list = [
+                "@{} ({})".format(v['id'], v['title'])
+                for v in ris
+            ]
+            ris_list_str = ", ".join(ris_list)
+            ris_list_pandoc = pf.convert_text(ris_list_str)
+            # convert_text returns a Para obj, copying its content in a Span obj
+            new_elem = pf.Span()
+            new_elem.content = ris_list_pandoc[0].content
+            return new_elem
 
 if __name__ == '__main__':
     pf.toJSONFilter(action)

--- a/test.md
+++ b/test.md
@@ -8,6 +8,8 @@ Other text
 
 ## Subtest test {#sec:sec_test ris="true"}
 
+## Second subtest {#sec:sec_second vex="true"}
+
 Vexatious clauses are @vex
 
 Per se termination clauses are @ris

--- a/test.md
+++ b/test.md
@@ -1,13 +1,13 @@
-ciao
+# Test {#sec:sec_tae vex="true" ris="true"}
 
-# prova {#sec:sec_tae vex="true" ris="true"}
+Text
 
-bene fg
+# Second test {#sec:sec_due ris="true" vex="true"}
 
-# Due {#sec:sec_due ris="true" vex="true"}
+Other text
 
-## test {#sec:sec_test ris="true"}
+## Subtest test {#sec:sec_test ris="true"}
 
-Le clausole vessatorie sono @vex
+Vexatious clauses are @vex
 
-Le clausole risolutive sono @ris
+Per se termination clauses are @ris

--- a/test.md
+++ b/test.md
@@ -1,0 +1,13 @@
+ciao
+
+# prova {#sec:sec_tae vex="true" ris="true"}
+
+bene fg
+
+# Due {#sec:sec_due ris="true" vex="true"}
+
+## test {#sec:sec_test ris="true"}
+
+Le clausole vessatorie sono @vex
+
+Le clausole risolutive sono @ris


### PR DESCRIPTION
Pandoc-vex only uses one variable. But it could be useful to create a second list. I have added two subconditions and one new variable to track not only 1341CC clauses, but also those which cause termination of the contract, in whichever order they are coded in the headings.

Therefore, the following code:

```markdown
# Test {#sec:sec_tae vex="true" ris="true"}

Text

# Second test {#sec:sec_due ris="true" vex="true"}

Other text 

## Subtest test {#sec:sec_test ris="true"}

Vexatious clauses are @vex

Per se termination clauses are @ris
```

Creates this result:

# Test

Text

# Second test

Other text

## Subtest test

Vexatious clauses are sec. 1 (Test), sec. 2 (Second test)

Per se termination clauses are sec. 1 (Test), sec. 2 (Second test), sec. 2.1 (Subtest test)